### PR TITLE
Use EeConfig for configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ Example of YAML configuration:
 
 ```yaml
 kumuluzee:
-  service-name: my-service
-  env: test
+  name: my-service
+  env:
+    name: test
   version: 1.2.3
-  base-url: http://localhost:8081
-  port: 8081
+  server:
+    http:
+      port: 8081
+    base-url: http://localhost:8081
   discovery:
     etcd:
       hosts: http://127.0.0.1:2379
@@ -102,10 +105,10 @@ If the service uses https protocol, tag `https` is added.
 Automatic service registration is enabled with the annotation `@RegisterService` on the REST application class (that extends 
 `javax.ws.rs.core.Application`). The annotation takes six parameters:
 
-- value: service name. Default value is fully classified class name. Service name can be overridden with configuration key `kumuluzee.service-name`.
+- value: service name. Default value is fully classified class name. Service name can be overridden with configuration key `kumuluzee.name`.
 - ttl: time to live of a registration key in the store. Default value is 30 seconds. TTL can be overridden with configuration key `kumuluzee.discovery.ttl`.
 - pingInterval: an interval in which service updates registration key value in the store. Default value is 20. Ping interval can be overridden with configuration key `kumuluzee.discovery.ping-interval`.
-- environment: environment in which service is registered. Default value is "dev". Environment can be overridden with configuration key `kumuluzee.env`.
+- environment: environment in which service is registered. Default value is "dev". Environment can be overridden with configuration key `kumuluzee.env.name`.
 - version: version of service to be registered. Default value is "1.0.0". Version can be overridden with configuration key `kumuluzee.version`.
 - singleton: if true ensures, that only one instance of service with the same name, version and environment is
 registered. Default value is false.
@@ -125,12 +128,12 @@ public class RestApplication extends Application {
 }
 ```
 
-To register a service with etcd, service URL has to be provided with the configuration key `kumuluzee.base-url` in 
+To register a service with etcd, service URL has to be provided with the configuration key `kumuluzee.server.base-url` in 
 the following format:`http://localhost:8080`. Consul implementation uses agent's IP address for the URL of registered 
 services, so this key is not used.
 
 KumuluzEE Discovery supports registration of multiple different versions of a service in different environments. The 
-environment can be set with the configuration key `kumuluzee.env`, the default value is `dev`. Service version can 
+environment can be set with the configuration key `kumuluzee.env.name`, the default value is `dev`. Service version can 
 also be set with the configuration key `kumuluzee.version`, the default value is `1.0.0`. Configuration keys will 
 override annotation values.
 
@@ -140,7 +143,7 @@ Service discovery is implemented by injecting fields with the annotation `@Disco
 
 - value: name of the service we want to inject.
 - environment: service environment, e.g. prod, dev, test. If value is not provided, environment is set to the value 
-defined with the configuration key `kumuluzee.env`. If the configuration key is not present, value is set to `dev`.
+defined with the configuration key `kumuluzee.env.name`. If the configuration key is not present, value is set to `dev`.
 - version: service version or NPM version range. Default value is "*", which resolves to the highest deployed 
 version (see chapter [NPM-like versioning](#npm-versioning)).
 - accessType: defines, which URL gets injected. Supported values are `AccessType.GATEWAY` and `AccessType.DIRECT`.
@@ -209,10 +212,10 @@ configuration key `kumuluzee.discovery.cluster`. Cluster id should be the same f
 cluster.
 
 Services running in the same cluster will be discovered by their container IP. Services accessing your service from
-outside the cluster will discover your service by its base url (`kumuluzee.baseurl`).
+outside the cluster will discover your service by its base url (`kumuluzee.server.base-url`).
 
 Container IP is automatically acquired when you run the service. If you want to override it, you can do so by 
-specifying configuration key `kumuluzee.containerurl`.
+specifying configuration key `kumuluzee.container-url`.
 
 ## Changelog
 

--- a/common/src/main/java/com/kumuluz/ee/discovery/utils/DiscoverServiceProducer.java
+++ b/common/src/main/java/com/kumuluz/ee/discovery/utils/DiscoverServiceProducer.java
@@ -20,6 +20,7 @@
 */
 package com.kumuluz.ee.discovery.utils;
 
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.discovery.annotations.DiscoverService;
 import com.kumuluz.ee.discovery.enums.AccessType;
@@ -94,7 +95,11 @@ public class DiscoverServiceProducer {
         AccessType accessType = injectionPoint.getAnnotated().getAnnotation(DiscoverService.class).accessType();
 
         if (environment.isEmpty()) {
-            environment = ConfigurationUtil.getInstance().get("kumuluzee.env").orElse("dev");
+            environment = EeConfig.getInstance().getEnv().getName();
+
+            if(environment == null || environment.isEmpty()) {
+                environment = ConfigurationUtil.getInstance().get("kumuluzee.env").orElse("dev");
+            }
         }
 
         log.info("Initializing field for service: " + serviceName + " version: " + version + " environment: " +

--- a/common/src/main/java/com/kumuluz/ee/discovery/utils/RegisterServiceUtil.java
+++ b/common/src/main/java/com/kumuluz/ee/discovery/utils/RegisterServiceUtil.java
@@ -20,6 +20,7 @@
 */
 package com.kumuluz.ee.discovery.utils;
 
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.discovery.annotations.RegisterService;
 
@@ -94,12 +95,17 @@ public class RegisterServiceUtil implements ServletContextListener {
             targetClass = targetClass.getSuperclass();
         }
 
-        String serviceName = configurationUtil.get("kumuluzee.service-name").orElse(null);
-        if(serviceName == null || serviceName.isEmpty()) {
-            serviceName = ((RegisterService) targetClass.getAnnotation(RegisterService.class)).value();
+        EeConfig eeConfig = EeConfig.getInstance();
 
-            if (serviceName.isEmpty()) {
-                serviceName = targetClass.getName();
+        String serviceName = eeConfig.getName();
+        if(serviceName == null || serviceName.isEmpty()) {
+            serviceName = configurationUtil.get("kumuluzee.service-name").orElse(null);
+            if (serviceName == null || serviceName.isEmpty()) {
+                serviceName = ((RegisterService) targetClass.getAnnotation(RegisterService.class)).value();
+
+                if (serviceName.isEmpty()) {
+                    serviceName = targetClass.getName();
+                }
             }
         }
 
@@ -121,21 +127,27 @@ public class RegisterServiceUtil implements ServletContextListener {
             }
         }
 
-        String environment = configurationUtil.get("kumuluzee.env").orElse(null);
-        if (environment == null || environment.isEmpty()) {
-            environment = ((RegisterService) targetClass.getAnnotation(RegisterService.class)).environment();
+        String environment = eeConfig.getEnv().getName();
+        if(environment == null || environment.isEmpty()) {
+            environment = configurationUtil.get("kumuluzee.env").orElse(null);
+            if (environment == null || environment.isEmpty()) {
+                environment = ((RegisterService) targetClass.getAnnotation(RegisterService.class)).environment();
 
-            if(environment.isEmpty()) {
-                environment = "dev";
+                if (environment.isEmpty()) {
+                    environment = "dev";
+                }
             }
         }
 
-        String version = configurationUtil.get("kumuluzee.version").orElse(null);
-        if (version == null || version.isEmpty()) {
-            version = ((RegisterService) targetClass.getAnnotation(RegisterService.class)).version();
+        String version = eeConfig.getVersion();
+        if(version == null || version.isEmpty()) {
+            version = configurationUtil.get("kumuluzee.version").orElse(null);
+            if (version == null || version.isEmpty()) {
+                version = ((RegisterService) targetClass.getAnnotation(RegisterService.class)).version();
 
-            if(version.isEmpty()) {
-                version = "1.0.0";
+                if (version.isEmpty()) {
+                    version = "1.0.0";
+                }
             }
         }
 

--- a/consul/src/main/java/com/kumuluz/ee/discovery/ConsulDiscoveryUtilImpl.java
+++ b/consul/src/main/java/com/kumuluz/ee/discovery/ConsulDiscoveryUtilImpl.java
@@ -61,7 +61,6 @@ public class ConsulDiscoveryUtilImpl implements DiscoveryUtil {
     private Map<String, List<ConsulService>> serviceInstances;
     private Map<String, Set<String>> serviceVersions;
     private Map<String, URL> gatewayUrls;
-    private int lastInstanceServedIndex;
 
     private int startRetryDelay;
     private int maxRetryDelay;

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
@@ -227,11 +227,11 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
             if (baseUrl == null || baseUrl.isEmpty()) {
                 if (ipUrl != null) {
                     log.warning("No service URL provided, using URL " + ipUrl.toString() +
-                            ". You should probably set service URL with configuration key kumuluzee.base-url");
+                            ". You should probably set service URL with configuration key kumuluzee.server.base-url");
                     baseUrl = ipUrl.toString();
                 } else {
                     log.severe("No service URL provided or found." +
-                            "Set service URL with configuration key kumuluzee.base-url");
+                            "Set service URL with configuration key kumuluzee.server.base-url");
                     return;
                 }
             }

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
@@ -20,6 +20,7 @@
 */
 package com.kumuluz.ee.discovery;
 
+import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.discovery.enums.AccessType;
 import com.kumuluz.ee.discovery.utils.*;
@@ -63,8 +64,6 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
 
     private List<Etcd2ServiceConfiguration> registeredServices;
 
-    private int lastInstanceServedIndex;
-
     private Map<String, Map<String, Etcd2Service>> serviceInstances;
     private Map<String, List<String>> serviceVersions;
     private Map<String, URL> gatewayUrls;
@@ -78,7 +77,6 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
 
         this.registeredServices = new LinkedList<>();
 
-        this.lastInstanceServedIndex = 0;
         this.serviceInstances = new HashMap<>();
         this.serviceVersions = new HashMap<>();
         this.gatewayUrls = new HashMap<>();
@@ -164,33 +162,27 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
     public void register(String serviceName, String version, String environment, long ttl,
                          long pingInterval, boolean singleton) {
 
+        EeConfig eeConfig = EeConfig.getInstance();
+
         // get service URL
-        String baseUrl = configurationUtil.get("kumuluzee.base-url").orElse(null);
-        if (baseUrl != null) {
-            try {
-                baseUrl = new URL(baseUrl).toString();
-            } catch (MalformedURLException e) {
-                log.severe("Cannot parse kumuluzee.base-url. Exception: " + e.toString());
-                baseUrl = null;
-            }
-        }
-        if (baseUrl == null) {
-            baseUrl = configurationUtil.get("kumuluzee.baseurl").orElse(null);
+        String baseUrl = eeConfig.getServer().getBaseUrl();
+        if(baseUrl == null || baseUrl.isEmpty()) {
+            baseUrl = configurationUtil.get("kumuluzee.base-url").orElse(null);
             if (baseUrl != null) {
                 try {
                     baseUrl = new URL(baseUrl).toString();
                 } catch (MalformedURLException e) {
-                    log.severe("Cannot parse kumuluzee.baseurl. Exception: " + e.toString());
+                    log.severe("Cannot parse kumuluzee.base-url. Exception: " + e.toString());
                     baseUrl = null;
                 }
             }
         }
-        String containerUrl = configurationUtil.get("kumuluzee.containerurl").orElse(null);
+        String containerUrl = configurationUtil.get("kumuluzee.container-url").orElse(null);
         if (containerUrl != null) {
             try {
                 containerUrl = new URL(containerUrl).toString();
             } catch (MalformedURLException e) {
-                log.severe("Cannot parse kumuluzee.containerurl. Exception: " + e.toString());
+                log.severe("Cannot parse kumuluzee.container-url. Exception: " + e.toString());
                 containerUrl = null;
             }
         }
@@ -211,7 +203,7 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
             }
             interfaceAddresses.sort(new HostAddressComparator());
             URL ipUrl = null;
-            String servicePort = configurationUtil.get("port").orElse("8080");
+            String servicePort = eeConfig.getServer().getHttp().getPort().toString();
             for (int i = 0; i < interfaceAddresses.size() && ipUrl == null; i++) {
                 InetAddress addr = interfaceAddresses.get(i);
                 try {
@@ -229,18 +221,17 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
                     containerUrl = ipUrl.toString();
                 } else if (containerUrl == null) {
                     log.severe("No container URL found, but running in container. All services will use service" +
-                            "URL. You can set container URL with configuration key kumuluzee.containerurl");
+                            "URL. You can set container URL with configuration key kumuluzee.container-url");
                 }
             }
             if (baseUrl == null || baseUrl.isEmpty()) {
                 if (ipUrl != null) {
-                    log.warning("No service URL provided, using ULR " + ipUrl.toString() +
-                            ". You should probably set service URL with configuration key kumuluzee.base-url or " +
-                            "kumuluzee.baseurl");
+                    log.warning("No service URL provided, using URL " + ipUrl.toString() +
+                            ". You should probably set service URL with configuration key kumuluzee.base-url");
                     baseUrl = ipUrl.toString();
                 } else {
                     log.severe("No service URL provided or found." +
-                            "Set service URL with configuration key kumuluzee.base-url or kumuluzee.baseurl");
+                            "Set service URL with configuration key kumuluzee.base-url");
                     return;
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kumuluzee.version>2.3.0-SNAPSHOT</kumuluzee.version>
+        <kumuluzee.version>2.4.0-SNAPSHOT</kumuluzee.version>
 
         <etcd4j.version>2.13.0</etcd4j.version>
         <consul-client.version>0.16.1</consul-client.version>


### PR DESCRIPTION
Uses new keys for namespace genaration:
- `kumuluzee.name`
- `kumuluzee.version`
- `kumuluzee.env.name`
- `kumuluzee.server.base-url`

If new keys are not present, old keys are checked for backwards compatibility.

Added dashes to config keys (base-url, container-url), since dashes in env vars are handled in core.

Updated KumuluzEE version to 2.4.0-SNAPSHOT.