### PR TITLE
Port to kumuluzee-logs

### DIFF
--- a/common/src/main/java/com/kumuluz/ee/discovery/utils/DiscoverServiceProducer.java
+++ b/common/src/main/java/com/kumuluz/ee/discovery/utils/DiscoverServiceProducer.java
@@ -23,6 +23,8 @@ package com.kumuluz.ee.discovery.utils;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.discovery.annotations.DiscoverService;
 import com.kumuluz.ee.discovery.enums.AccessType;
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
@@ -34,7 +36,6 @@ import javax.ws.rs.client.WebTarget;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 /**
  * Producer for DiscoverService annotation.
@@ -42,7 +43,7 @@ import java.util.logging.Logger;
 @RequestScoped
 public class DiscoverServiceProducer {
 
-    private static final Logger log = Logger.getLogger(DiscoverServiceProducer.class.getName());
+    private static final Logger log = LogManager.getLogger(DiscoverServiceProducer.class.getName());
 
     @Inject
     private DiscoveryUtil discoveryUtil;

--- a/common/src/main/java/com/kumuluz/ee/discovery/utils/RegisterServiceUtil.java
+++ b/common/src/main/java/com/kumuluz/ee/discovery/utils/RegisterServiceUtil.java
@@ -22,6 +22,8 @@ package com.kumuluz.ee.discovery.utils;
 
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.discovery.annotations.RegisterService;
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
@@ -35,7 +37,6 @@ import javax.ws.rs.core.Application;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.logging.Logger;
 
 /**
  * Interceptor class for RegisterService annotation.
@@ -44,7 +45,7 @@ import java.util.logging.Logger;
 @WebListener
 public class RegisterServiceUtil implements ServletContextListener {
 
-    private static final Logger log = Logger.getLogger(RegisterServiceUtil.class.getName());
+    private static final Logger log = LogManager.getLogger(RegisterServiceUtil.class.getName());
 
     private boolean beanInitialised;
     private boolean deregistratorEnabled;

--- a/consul/src/main/java/com/kumuluz/ee/discovery/ConsulDiscoveryExtension.java
+++ b/consul/src/main/java/com/kumuluz/ee/discovery/ConsulDiscoveryExtension.java
@@ -27,8 +27,8 @@ import com.kumuluz.ee.common.dependencies.EeComponentType;
 import com.kumuluz.ee.common.dependencies.EeExtensionDef;
 import com.kumuluz.ee.common.dependencies.EeExtensionType;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
-
-import java.util.logging.Logger;
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 
 /**
  * KumuluzEE framework extension for Consul-based service discovery
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 @EeComponentDependency(EeComponentType.CDI)
 public class ConsulDiscoveryExtension implements Extension {
 
-    private static final Logger log = Logger.getLogger(ConsulDiscoveryExtension.class.getName());
+    private static final Logger log = LogManager.getLogger(ConsulDiscoveryExtension.class.getName());
 
     @Override
     public void init(KumuluzServerWrapper kumuluzServerWrapper, EeConfig eeConfig) {

--- a/consul/src/main/java/com/kumuluz/ee/discovery/utils/ConsulService.java
+++ b/consul/src/main/java/com/kumuluz/ee/discovery/utils/ConsulService.java
@@ -20,18 +20,19 @@
 */
 package com.kumuluz.ee.discovery.utils;
 
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 import com.orbitz.consul.model.health.ServiceHealth;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.logging.Logger;
 
 /**
  * @author Jan Meznarič, Urban Malc
  */
 public class ConsulService {
 
-    private static final Logger log = Logger.getLogger(ConsulService.class.getName());
+    private static final Logger log = LogManager.getLogger(ConsulService.class.getName());
 
     public static final String TAG_HTTPS = "https";
     public static final String TAG_VERSION_PREFIX = "version=";
@@ -83,7 +84,7 @@ public class ConsulService {
             return new URL(((serviceHealth.getService().getTags().contains(TAG_HTTPS)) ? "https" : "http")
                     + "://" + serviceHealth.getNode().getAddress() + ":" + serviceHealth.getService().getPort());
         } catch (MalformedURLException e) {
-            log.severe("Malformed URL when translating serviceHealth to URL: " + e.getLocalizedMessage());
+            log.error("Malformed URL when translating serviceHealth to URL.", e);
         }
 
         return null;

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryExtension.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryExtension.java
@@ -25,8 +25,8 @@ import com.kumuluz.ee.common.Extension;
 import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.dependencies.*;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
-
-import java.util.logging.Logger;
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 
 /**
  * KumuluzEE framework extension for etcd-based service discovery
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 })
 public class Etcd2DiscoveryExtension implements Extension {
 
-    private static final Logger log = Logger.getLogger(Etcd2DiscoveryExtension.class.getName());
+    private static final Logger log = LogManager.getLogger(Etcd2DiscoveryExtension.class.getName());
 
     @Override
     public void init(KumuluzServerWrapper kumuluzServerWrapper, EeConfig eeConfig) {

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
@@ -544,6 +544,11 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
                     if (((EtcdException) t).isErrorCode(EtcdErrorCode.NodeExist)) {
                         log.error("Exception in etcd promise.", t);
                     }
+                    if(((EtcdException) t).isErrorCode(EtcdErrorCode.EventIndexCleared)) {
+                        // index to old, reset watch to new index
+                        watchServiceInstances(key, ((EtcdException) t).getIndex());
+                        return;
+                    }
                 }
 
                 EtcdKeysResponse.EtcdNode node = promise.getNow().getNode();

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
@@ -435,8 +435,19 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
 
                     String version = Etcd2Utils.getLastKeyLayer(versionNode.getKey());
 
+                    EtcdKeysResponse.EtcdNode instanceParentNode = null;
+                    for(EtcdKeysResponse.EtcdNode instanceParentNodeCandidate : versionNode.getNodes()) {
+                        if(Etcd2Utils.getLastKeyLayer(instanceParentNodeCandidate.key).equals("instances")) {
+                            instanceParentNode = instanceParentNodeCandidate;
+                            break;
+                        }
+                    }
+                    if(instanceParentNode == null) {
+                        continue;
+                    }
+
                     boolean versionActive = false;
-                    for (EtcdKeysResponse.EtcdNode instanceNode : versionNode.getNodes().get(0).getNodes()) {
+                    for (EtcdKeysResponse.EtcdNode instanceNode : instanceParentNode.getNodes()) {
 
                         String url = null;
                         String status = null;

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2Registrator.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2Registrator.java
@@ -22,6 +22,8 @@ package com.kumuluz.ee.discovery;
 
 import com.kumuluz.ee.discovery.utils.Etcd2ServiceConfiguration;
 import com.kumuluz.ee.discovery.utils.Etcd2Utils;
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 import mousio.etcd4j.EtcdClient;
 import mousio.etcd4j.responses.EtcdAuthenticationException;
 import mousio.etcd4j.responses.EtcdException;
@@ -29,7 +31,6 @@ import mousio.etcd4j.responses.EtcdKeysResponse;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.Logger;
 
 /**
  * Runnable for service registration and heartbeats
@@ -37,7 +38,7 @@ import java.util.logging.Logger;
  * @author Jan Meznarič, Urban Malc
  */
 public class Etcd2Registrator implements Runnable {
-    private static final Logger log = Logger.getLogger(Etcd2Registrator.class.getName());
+    private static final Logger log = LogManager.getLogger(Etcd2Registrator.class.getName());
 
     private EtcdClient etcd;
     private Etcd2ServiceConfiguration serviceConfig;
@@ -63,7 +64,7 @@ public class Etcd2Registrator implements Runnable {
                 e.printStackTrace();
             } catch (EtcdException e) {
                 if (e.isErrorCode(100)) {
-                    log.warning("Etcd key not present: " + this.serviceConfig.getServiceInstanceKey() +
+                    log.warn("Etcd key not present: " + this.serviceConfig.getServiceInstanceKey() +
                             ". Reregistering service.");
 
                     this.isRegistered = false;
@@ -78,7 +79,7 @@ public class Etcd2Registrator implements Runnable {
     private void registerToEtcd() {
         if (this.serviceConfig.isSingleton() && isRegistered()) {
 
-            log.warning("Instance was not registered. Trying to register a singleton microservice instance, but " +
+            log.warn("Instance was not registered. Trying to register a singleton microservice instance, but " +
                     "another instance is already registered.");
 
         } else {
@@ -101,16 +102,16 @@ public class Etcd2Registrator implements Runnable {
 
                     this.isRegistered = true;
                 } catch (IOException e) {
-                    log.info("IO Exception. Cannot read given key: " + e);
+                    log.info("IO Exception. Cannot read given key.", e);
                 } catch (EtcdException e) {
-                    log.info("Etcd exception. " + e);
+                    log.info("Etcd exception.", e);
                 } catch (EtcdAuthenticationException e) {
-                    log.severe("Etcd authentication exception. Cannot read given key: " + e);
+                    log.error("Etcd authentication exception. Cannot read given key.", e);
                 } catch (TimeoutException e) {
-                    log.severe("Timeout exception. Cannot read given key time: " + e);
+                    log.error("Timeout exception. Cannot read given key time.", e);
                 }
             } else {
-                log.severe("etcd not initialised.");
+                log.error("etcd not initialised.");
             }
 
         }

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/utils/Etcd2Utils.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/utils/Etcd2Utils.java
@@ -20,6 +20,8 @@
 */
 package com.kumuluz.ee.discovery.utils;
 
+import com.kumuluz.ee.logs.LogManager;
+import com.kumuluz.ee.logs.Logger;
 import mousio.etcd4j.EtcdClient;
 import mousio.etcd4j.responses.EtcdAuthenticationException;
 import mousio.etcd4j.responses.EtcdException;
@@ -27,7 +29,6 @@ import mousio.etcd4j.responses.EtcdKeysResponse;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.Logger;
 
 /**
  * etcd utils
@@ -35,7 +36,7 @@ import java.util.logging.Logger;
  * @author Urban Malc
  */
 public class Etcd2Utils {
-    private static final Logger log = Logger.getLogger(Etcd2Utils.class.getName());
+    private static final Logger log = LogManager.getLogger(Etcd2Utils.class.getName());
 
     public static EtcdKeysResponse getEtcdDir(EtcdClient etcd, String key) {
 
@@ -46,17 +47,17 @@ public class Etcd2Utils {
             try {
                 etcdKeysResponse = etcd.getDir(key).recursive().send().get();
             } catch (IOException e) {
-                log.info("IO Exception. Cannot read given key: " + e);
+                log.info("IO Exception. Cannot read given key", e);
             } catch (EtcdException e) {
-                log.info("Etcd exception. " + e);
+                log.info("Etcd exception.", e);
             } catch (EtcdAuthenticationException e) {
-                log.severe("Etcd authentication exception. Cannot read given key: " + e);
+                log.error("Etcd authentication exception. Cannot read given key.", e);
             } catch (TimeoutException e) {
-                log.severe("Timeout exception. Cannot read given key time: " + e);
+                log.error("Timeout exception. Cannot read given key time.", e);
             }
 
         } else {
-            log.severe("etcd not initialised.");
+            log.error("etcd not initialised.");
         }
 
         return etcdKeysResponse;


### PR DESCRIPTION
Ported from java.util.Logger logging to kumuluzee-logs.

Also fixed some bugs in etcd implementation:
- correctly resetting watch, if etcd index is too old and etcd deletes relevant history
- fixed node selection when scanning etcd response for versions