### PR TITLE
Resilience toggle

### DIFF
--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
@@ -167,16 +167,16 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
 
             int initialRetryCount = configurationUtil.getInteger("kumuluzee.discovery.etcd.initial-retry-count")
                     .orElse(2);
-            if(initialRetryCount == 0) {
+            if (initialRetryCount == 0) {
                 this.initialRequestRetryPolicy = zeroRetryPolicy;
-            } else if(initialRetryCount > 0) {
+            } else if (initialRetryCount > 0) {
                 this.initialRequestRetryPolicy = new RetryWithExponentialBackOff(startRetryDelay, initialRetryCount,
                         maxRetryDelay);
             } else {
                 this.initialRequestRetryPolicy = defaultRetryPolicy;
             }
 
-            if(!resilience) {
+            if (!resilience) {
                 // set default and initial request retry policies to zero retry
                 etcd.setRetryHandler(zeroRetryPolicy);
                 this.initialRequestRetryPolicy = zeroRetryPolicy;
@@ -305,7 +305,7 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
             }
         }
 
-        for(ScheduledFuture handle : this.registratorHandles) {
+        for (ScheduledFuture handle : this.registratorHandles) {
             handle.cancel(true);
         }
     }
@@ -416,7 +416,7 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
                 gatewayUrl = new URL(etcdKeysResponse.getNode().getValue());
             } catch (SocketException | TimeoutException e) {
                 String message = "Timeout exception. Cannot read given key in time";
-                if(resilience) {
+                if (resilience) {
                     log.severe(message + ": " + e);
                 } else {
                     throw new EtcdNotAvailableException(message, e);
@@ -865,7 +865,7 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
                 etcd.put(key, value).send().get();
             } catch (SocketException | TimeoutException e) {
                 String message = "Timeout exception. Cannot put given key in time";
-                if(resilience) {
+                if (resilience) {
                     log.severe(message + ": " + e);
                 } else {
                     throw new EtcdNotAvailableException(message, e);

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2Registrator.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2Registrator.java
@@ -20,6 +20,7 @@
 */
 package com.kumuluz.ee.discovery;
 
+import com.kumuluz.ee.discovery.exceptions.EtcdNotAvailableException;
 import com.kumuluz.ee.discovery.utils.Etcd2ServiceConfiguration;
 import com.kumuluz.ee.discovery.utils.Etcd2Utils;
 import mousio.etcd4j.EtcdClient;
@@ -28,6 +29,7 @@ import mousio.etcd4j.responses.EtcdException;
 import mousio.etcd4j.responses.EtcdKeysResponse;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
@@ -41,12 +43,14 @@ public class Etcd2Registrator implements Runnable {
 
     private EtcdClient etcd;
     private Etcd2ServiceConfiguration serviceConfig;
+    private boolean resilience;
 
     private boolean isRegistered;
 
-    public Etcd2Registrator(EtcdClient etcd, Etcd2ServiceConfiguration serviceConfig) {
+    public Etcd2Registrator(EtcdClient etcd, Etcd2ServiceConfiguration serviceConfig, boolean resilience) {
         this.etcd = etcd;
         this.serviceConfig = serviceConfig;
+        this.resilience = resilience;
     }
 
     public void run() {
@@ -59,8 +63,12 @@ public class Etcd2Registrator implements Runnable {
             try {
                 this.etcd.putDir(this.serviceConfig.getServiceInstanceKey()).prevExist(true)
                         .refresh(this.serviceConfig.getTtl()).send().get();
-            } catch (IOException | EtcdAuthenticationException | TimeoutException e) {
-                e.printStackTrace();
+            } catch (SocketException | TimeoutException e) {
+                handleTimeoutException(e);
+            } catch (IOException e) {
+                log.info("IO Exception. Cannot put given key: " + e);
+            } catch(EtcdAuthenticationException e) {
+                log.severe("Etcd authentication exception. Cannot put given key: " + e);
             } catch (EtcdException e) {
                 if (e.isErrorCode(100)) {
                     log.warning("Etcd key not present: " + this.serviceConfig.getServiceInstanceKey() +
@@ -100,14 +108,14 @@ public class Etcd2Registrator implements Runnable {
                     }
 
                     this.isRegistered = true;
+                } catch (SocketException | TimeoutException e) {
+                    handleTimeoutException(e);
                 } catch (IOException e) {
-                    log.info("IO Exception. Cannot read given key: " + e);
+                    log.info("IO Exception. Cannot put given key: " + e);
                 } catch (EtcdException e) {
                     log.info("Etcd exception. " + e);
                 } catch (EtcdAuthenticationException e) {
-                    log.severe("Etcd authentication exception. Cannot read given key: " + e);
-                } catch (TimeoutException e) {
-                    log.severe("Timeout exception. Cannot read given key time: " + e);
+                    log.severe("Etcd authentication exception. Cannot put given key: " + e);
                 }
             } else {
                 log.severe("etcd not initialised.");
@@ -120,7 +128,7 @@ public class Etcd2Registrator implements Runnable {
         String serviceInstancesKey = Etcd2Utils.getServiceKeyInstances(this.serviceConfig.getEnvironment(),
                 this.serviceConfig.getServiceName(), this.serviceConfig.getServiceVersion());
 
-        EtcdKeysResponse etcdKeysResponse = Etcd2Utils.getEtcdDir(this.etcd, serviceInstancesKey);
+        EtcdKeysResponse etcdKeysResponse = Etcd2Utils.getEtcdDir(this.etcd, serviceInstancesKey, this.resilience);
 
         if (etcdKeysResponse != null) {
             for (EtcdKeysResponse.EtcdNode node : etcdKeysResponse.getNode().getNodes()) {
@@ -147,5 +155,17 @@ public class Etcd2Registrator implements Runnable {
         }
 
         return false;
+    }
+
+    private void handleTimeoutException(Throwable e) {
+        String message = "Timeout exception. Cannot put given key in time";
+        if(resilience) {
+            log.severe(message + ": " + e);
+        } else {
+            RuntimeException ex = new EtcdNotAvailableException(message, e);
+            // print stack trace, because Exceptions in scheduler are not reported
+            ex.printStackTrace();
+            throw ex; // stops the scheduler
+        }
     }
 }

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2Registrator.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2Registrator.java
@@ -67,7 +67,7 @@ public class Etcd2Registrator implements Runnable {
                 handleTimeoutException(e);
             } catch (IOException e) {
                 log.info("IO Exception. Cannot put given key: " + e);
-            } catch(EtcdAuthenticationException e) {
+            } catch (EtcdAuthenticationException e) {
                 log.severe("Etcd authentication exception. Cannot put given key: " + e);
             } catch (EtcdException e) {
                 if (e.isErrorCode(100)) {
@@ -98,11 +98,11 @@ public class Etcd2Registrator implements Runnable {
                     etcd.putDir(this.serviceConfig.getServiceInstanceKey()).ttl(this.serviceConfig.getTtl())
                             .send().get();
                     etcd.put(this.serviceConfig.getServiceKeyUrl(), this.serviceConfig.getBaseUrl()).send().get();
-                    if(this.serviceConfig.getContainerUrl() != null) {
+                    if (this.serviceConfig.getContainerUrl() != null) {
                         etcd.put(this.serviceConfig.getServiceInstanceKey() + "/containerUrl",
                                 this.serviceConfig.getContainerUrl()).send().get();
                     }
-                    if(this.serviceConfig.getClusterId() != null) {
+                    if (this.serviceConfig.getClusterId() != null) {
                         etcd.put(this.serviceConfig.getServiceInstanceKey() + "/clusterId",
                                 this.serviceConfig.getClusterId()).send().get();
                     }
@@ -159,7 +159,7 @@ public class Etcd2Registrator implements Runnable {
 
     private void handleTimeoutException(Throwable e) {
         String message = "Timeout exception. Cannot put given key in time";
-        if(resilience) {
+        if (resilience) {
             log.severe(message + ": " + e);
         } else {
             RuntimeException ex = new EtcdNotAvailableException(message, e);

--- a/etcd/src/main/java/com/kumuluz/ee/discovery/exceptions/EtcdNotAvailableException.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/exceptions/EtcdNotAvailableException.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+*/
+package com.kumuluz.ee.discovery.exceptions;
+
+/**
+ * @author Urban Malc
+ * @author Jan Meznarič
+ */
+public class EtcdNotAvailableException extends RuntimeException {
+
+    public EtcdNotAvailableException(String message, Throwable e) {
+        super(message, e);
+    }
+}


### PR DESCRIPTION
- toggle resilience mode with `kumuluzee.discovery.resilience` (`false`: no retries on all etcd requests, exceptions thrown on timeouts)
- close registrator `Runnable` handles on deregister