### PR TITLE
Etcd fix, that enables usage of lower version instances if available

### DIFF
--- a/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
+++ b/etcd/src/main/java/com/kumuluz/ee/discovery/Etcd2DiscoveryUtilImpl.java
@@ -603,19 +603,14 @@ public class Etcd2DiscoveryUtilImpl implements DiscoveryUtil {
 
         List<String> presentVersions = this.serviceVersions.get(serviceName + "_" + environment);
 
-        String lastKnownVersion = lastKnownVersions.get(serviceName + "_" + environment);
-        if (lastKnownVersion != null && (presentVersions == null || !presentVersions.contains(lastKnownVersion))) {
-            // if present versions does not contain version of last known service, add it to the return object
-
-            // make a copy of presentVersions
-            if (presentVersions != null) {
-                presentVersions = new LinkedList<>(presentVersions);
-            } else {
-                presentVersions = new LinkedList<>();
+        if(presentVersions == null || presentVersions.size() == 0) {
+            // we check last known version if there are no present versions left
+            presentVersions = new LinkedList<>();
+            String lastKnownVersion = lastKnownVersions.get(serviceName + "_" + environment);
+            if (lastKnownVersion != null) {
+                presentVersions.add(lastKnownVersion);
             }
-            presentVersions.add(lastKnownVersion);
         }
-
         return Optional.ofNullable(presentVersions);
     }
 


### PR DESCRIPTION
This commit fixes the ability to use lower versions. For example: let's say that there are two instances with different versions: 1.0.0 and 1.0.1. If you target 1.0.x, and the 1.0.1 instance goes offline, the result is not the expected 1.0.0 (which is still online). Instead, discovery return last known address of 1.0.1 instance, which is probably offline.